### PR TITLE
Array.isArray → instanceof Array (IE fix)

### DIFF
--- a/src/geodist.coffee
+++ b/src/geodist.coffee
@@ -50,7 +50,7 @@ parseCoordinates = (point = [0,0]) ->
 
   coords = []
 
-  if Array.isArray(point)
+  if point instanceof Array
     coords = point
   else if point.lat? and point.lon?
     coords = [point.lat, point.lon]


### PR DESCRIPTION
There is no isArray method of Array in IE 8, but module should work on every modern client.
